### PR TITLE
Fix some text and make the click on the logo go back to the landing page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -143,6 +143,7 @@ const config = {
           alt: "CITROS Logo",
           // src: 'img/logo.svg',
           src: "img/citros.png",
+          href: "https://citros.io",
         },
         items: [
           {

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -43,7 +43,7 @@ const FeatureList: FeatureItem[] = [
       Svg: require('@site/static/img/citros_home_analysis.svg').default,
       description: (
         <div>
-          <p>CITROS Data Analysis offers you to data query, analyse and visualize it. With its extensive features, you can easily extract valuable insights from your data.</p>
+          <p>CITROS Data Analysis allows you to query, analyse and visualize the data of your simulations. With its extensive features, you can easily extract valuable insights from your simulation runs.</p>
           <p>Read more...</p>
         </div>
       ),


### PR DESCRIPTION
I don't know how to test the click on the logo. But really confusing that it does not go back to the landing page.
Also, in the blog section:
- Says "One minute read" and it's a 18 minutes video.
- The video of ROSCon talk cannot be clicked to full screen. Something missing.