### PR TITLE
feat(src/theme/CodeBlock/): copy code

### DIFF
--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -12,7 +12,7 @@ export default function CopyButton({code, className}) {
   const handleCopyCode = useCallback(() => {
     const modifiedCode = code
       .split('\n')
-      .map(line => (line.startsWith('>>> ') ? line.substring(4) : line))
+      .map(line => (line.startsWith('>>> ') ? line.substring(4) : (line.startsWith('$ ') ? line.substring(2) : line)))
       .join('\n');
     copy(modifiedCode);
     setIsCopied(true);


### PR DESCRIPTION
'$ ' in the beginning of the code block is now unselectable and is not copied by copy button